### PR TITLE
ci(golangci): ignore additional repeated strings in goconst

### DIFF
--- a/.github/linters/.golangci.yaml
+++ b/.github/linters/.golangci.yaml
@@ -194,7 +194,20 @@ linters:
         - "^failOnError$"
     goconst:
       min-occurrences: 5
-      ignore-string-values: ["CUSTOMERS"]
+      ignore-string-values:
+        - "CUSTOMERS"
+        - "badDataSourceCode"
+        - "badEntityID"
+        - "badRecordID"
+        - "dataSourceCode"
+        - "default"
+        - "entityID"
+        - "flags"
+        - "nilDataSourceCode"
+        - "nilEntityID"
+        - "nilRecordID"
+        - "recordID"
+        - "withInfo"
     tagliatelle:
       case:
         rules:


### PR DESCRIPTION
Adds JSON observer keys and test-case name strings to goconst ignore-string-values to fix Lint failures under golangci-lint v2.12+.

# Pull request questions

## Which issue does this address

Issue number: #356

## Why was change needed

The Lint CI job (golangci-lint with `version: latest`, now v2.12+) flags repeated strings via `goconst` in `szengine/szengine.go` (observer-notification map keys) and `szengine/szengine_test.go` (test-case `name` fields). This blocks dependabot PRs like #354 from passing CI.

## What does change improve

Unblocks Lint by extending the existing `ignore-string-values` allowlist (`CUSTOMERS` was already there) instead of churning real source code with constants for what are really ad-hoc test-case names and JSON observer keys.

Verified locally with golangci-lint v2.10.1 and v2.12.2 — both report `0 issues` against the project.

---

Resolves #356
Resolves #354